### PR TITLE
pager-less: keep data on-screen after hitting ESC

### DIFF
--- a/src/internal_commands.rs
+++ b/src/internal_commands.rs
@@ -41,6 +41,7 @@ fn page_output(session: &Session, data: &str) -> Result<(), std::io::Error> {
         let mut pager = Command::new("less")
             // Exit immediately if the data fits on one screen.
             .arg("-F")
+            .arg("-X")
             .stdin(Stdio::piped())
             .spawn()?;
 


### PR DESCRIPTION
Usually network operator issue `show run` and then copy-paste some output from the running-configuration. 
With `less` pager default behavior, this is not possible. (screen is cleared). With `-X` option, output data is kept on screen. 