### PR TITLE
Fix panic on "show ospfv2 neighbor 3.3.3.3"

### DIFF
--- a/src/internal_commands.rs
+++ b/src/internal_commands.rs
@@ -1078,7 +1078,7 @@ pub fn cmd_show_ospf_neighbor(
         .column_leaf("Interface", "name")
         .xpath(XPATH_OSPF_NEIGHBOR)
         .filter_list_key(
-            "neighbor-router-id=",
+            "neighbor-router-id",
             get_opt_arg(&mut args, "router_id"),
         )
         .column_from_fn(


### PR DESCRIPTION
One symbol fix to prevent panic when running "show ospfv2 neighbor x.x.x.x"

```
clab-bgp-rt4# show ospfv2 neighbor 3.3.3.3

thread 'main' (2739917) panicked at src/internal_commands.rs:170:46:
called `Result::unwrap()` on an `Err` value: Error { errcode: 7, msg: Some("Unexpected XPath token \"Operator(Equal)\" (\"='3.3.3.3']\")."), path: None, apptag: None }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```