### PR TITLE
grpc: split combined Get RPC into GetState and GetConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,9 +2029,9 @@ checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "yang5"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5ebbf669599b5c407efa54e675230eb61d963a3d7452ddea205b6819a24064"
+checksum = "1da35149085196bd35c11637c084c0723157c05d97766033cec6d90db535bd19"
 dependencies = [
  "bitflags 2.9.0",
  "libc",

--- a/proto/holo.proto
+++ b/proto/holo.proto
@@ -32,8 +32,11 @@ service Northbound {
   // Retrieve the specified schema data from the target.
   rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {}
 
-  // Retrieve configuration data, state data or both from the target.
-  rpc Get(GetRequest) returns (GetResponse) {}
+  // Retrieve state data from the target.
+  rpc GetState(GetStateRequest) returns (GetStateResponse) {}
+
+  // Retrieve configuration data from the target.
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse) {}
 
   // Validate the configuration without committing it.
   rpc Validate(ValidateRequest) returns (ValidateResponse) {}
@@ -134,15 +137,47 @@ message GetRequest {
   Path path = 4;
 }
 
-message GetResponse {
-  // Return values:
-  // - grpc::StatusCode::OK: Success.
-  // - grpc::StatusCode::INVALID_ARGUMENT: Invalid YANG data path.
+//
+// RPC: GetState()
+//
+message GetStateRequest {
+  // Encoding to be used.
+  Encoding encoding = 1;
 
+  // Include implicit default nodes.
+  bool with_defaults = 2;
+
+  // Target YANG path.
+  Path path = 3;
+}
+
+message GetStateResponse {
   // Timestamp in nanoseconds since Epoch.
   int64 timestamp = 1;
 
-  // The requested data.
+  // The requested state data.
+  DataTree data = 2;
+}
+
+//
+// RPC: GetConfig()
+//
+message GetConfigRequest {
+  // Encoding to be used.
+  Encoding encoding = 1;
+
+  // Include implicit default nodes.
+  bool with_defaults = 2;
+
+  // Target YANG path.
+  Path path = 3;
+}
+
+message GetConfigResponse {
+  // Timestamp in nanoseconds since Epoch.
+  int64 timestamp = 1;
+
+  // The requested configuration data.
   DataTree data = 2;
 }
 

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -10,7 +10,8 @@ use std::os::raw::{c_char, c_void};
 
 use proto::northbound_client::NorthboundClient;
 use yang5::data::{
-    Data, DataDiffFlags, DataFormat, DataPrinterFlags, DataTree,
+    Data, DataDiffFlags, DataFormat, DataParserFlags, DataPrinterFlags,
+    DataTree, DataValidationFlags,
 };
 use yang5::ffi;
 
@@ -102,19 +103,98 @@ impl GrpcClient {
         with_defaults: bool,
         xpath: Option<String>,
     ) -> Result<proto::data_tree::Data, Error> {
+        use proto::get_request::DataType;
+
+        // holod (>= the "separate state and configuration retrieval" change)
+        // replaced the combined `Get` RPC with dedicated `GetConfig` and
+        // `GetState` RPCs. Dispatch accordingly, reassembling the `ALL` union
+        // by merging both data trees.
         let path = xpath.map(|x| proto::Path::from_xpath(&x));
-        let data = self
-            .rpc_sync_get(proto::GetRequest {
-                r#type: data_type as i32,
-                encoding: proto::Encoding::from(format) as i32,
-                with_defaults,
-                path,
-            })
-            .map_err(Error::Backend)?
-            .into_inner()
-            .data
-            .unwrap();
-        Ok(data.data.unwrap())
+        let encoding = proto::Encoding::from(format) as i32;
+
+        match data_type {
+            DataType::Config => {
+                let data = self
+                    .rpc_sync_get_config(proto::GetConfigRequest {
+                        encoding,
+                        with_defaults,
+                        path,
+                    })
+                    .map_err(Error::Backend)?
+                    .into_inner()
+                    .data
+                    .unwrap();
+                Ok(data.data.unwrap())
+            }
+            DataType::State => {
+                let data = self
+                    .rpc_sync_get_state(proto::GetStateRequest {
+                        encoding,
+                        with_defaults,
+                        path,
+                    })
+                    .map_err(Error::Backend)?
+                    .into_inner()
+                    .data
+                    .unwrap();
+                Ok(data.data.unwrap())
+            }
+            DataType::All => {
+                let config = self
+                    .rpc_sync_get_config(proto::GetConfigRequest {
+                        encoding,
+                        with_defaults,
+                        path: path.clone(),
+                    })
+                    .map_err(Error::Backend)?
+                    .into_inner()
+                    .data
+                    .unwrap()
+                    .data
+                    .unwrap();
+                let state = self
+                    .rpc_sync_get_state(proto::GetStateRequest {
+                        encoding,
+                        with_defaults,
+                        path,
+                    })
+                    .map_err(Error::Backend)?
+                    .into_inner()
+                    .data
+                    .unwrap()
+                    .data
+                    .unwrap();
+
+                let yang_ctx = crate::YANG_CTX.get().unwrap();
+                let mut tree = Self::parse_data(yang_ctx, &config, format);
+                let state_tree = Self::parse_data(yang_ctx, &state, format);
+                tree.merge(&state_tree)
+                    .expect("Failed to merge config and state data trees");
+                Ok(proto::DataTree::new(format, &tree).data.unwrap())
+            }
+        }
+    }
+
+    // Parses a `data_tree::Data` payload (as returned by GetConfig/GetState)
+    // back into a YANG data tree so that the `ALL` union can be reassembled.
+    fn parse_data<'a>(
+        yang_ctx: &'a std::sync::Arc<yang5::context::Context>,
+        data: &proto::data_tree::Data,
+        format: DataFormat,
+    ) -> DataTree<'a> {
+        let (string, bytes) = match data {
+            proto::data_tree::Data::DataString(s) => (s.as_str(), None),
+            proto::data_tree::Data::DataBytes(b) => ("", Some(b.as_slice())),
+        };
+        let input = bytes.unwrap_or(string.as_bytes());
+        DataTree::parse_string(
+            yang_ctx,
+            input,
+            format,
+            DataParserFlags::NO_VALIDATION,
+            DataValidationFlags::PRESENT,
+        )
+        .expect("Failed to parse data tree")
     }
 
     pub fn validate_candidate(
@@ -183,12 +263,20 @@ impl GrpcClient {
         self.runtime.block_on(self.client.get_schema(request))
     }
 
-    fn rpc_sync_get(
+    fn rpc_sync_get_state(
         &mut self,
-        request: proto::GetRequest,
-    ) -> Result<tonic::Response<proto::GetResponse>, tonic::Status> {
+        request: proto::GetStateRequest,
+    ) -> Result<tonic::Response<proto::GetStateResponse>, tonic::Status> {
         let request = tonic::Request::new(request);
-        self.runtime.block_on(self.client.get(request))
+        self.runtime.block_on(self.client.get_state(request))
+    }
+
+    fn rpc_sync_get_config(
+        &mut self,
+        request: proto::GetConfigRequest,
+    ) -> Result<tonic::Response<proto::GetConfigResponse>, tonic::Status> {
+        let request = tonic::Request::new(request);
+        self.runtime.block_on(self.client.get_config(request))
     }
 
     fn rpc_sync_commit(
@@ -266,7 +354,8 @@ impl proto::Path {
                     Some(pos) => {
                         let name = &segment[..pos];
                         let mut keys = HashMap::new();
-                        for kv in segment[pos..].split('[').filter(|s| !s.is_empty())
+                        for kv in
+                            segment[pos..].split('[').filter(|s| !s.is_empty())
                         {
                             let kv = kv.trim_end_matches(']');
                             if let Some(eq_pos) = kv.find('=') {

--- a/src/internal_commands.rs
+++ b/src/internal_commands.rs
@@ -2135,7 +2135,7 @@ pub fn cmd_show_bgp_neighbor(
     let data =
         fetch_data(session, proto::get_request::DataType::State, &xpath_req)?;
 
-    let xpath_routes = format!("{}/route", &xpath_req);
+    let xpath_routes = format!("{}/route", xpath_req);
 
     let output = session.writer();
 
@@ -2461,12 +2461,12 @@ pub fn cmd_clear_bgp_neighbor(
             "soft-in" => "soft-inbound",
             op => op,
         };
-        let xpath = format!("{}/{}", &xpath, operation);
+        let xpath = format!("{}/{}", xpath, operation);
         clear_req.new_path(&xpath, None, false).unwrap();
     }
 
     if neighbor.is_some() {
-        let xpath = format!("{}/holo-bgp:remote-addr", &xpath);
+        let xpath = format!("{}/holo-bgp:remote-addr", xpath);
         clear_req
             .new_path(&xpath, neighbor.as_deref(), false)
             .unwrap();


### PR DESCRIPTION
holod replaced the combined `Get` RPC with separate `GetState` and `GetConfig` RPCs, so holo-cli's old `Get` calls now fail with `Unimplemented`, breaking `show state`, `show ... route`, the startup config load, etc.

Sync `proto/holo.proto` with holod and dispatch in `GrpcClient::get()`:

- `Config` → `GetConfig`
- `State` → `GetState`
- `All` → issue both and merge the two data trees
